### PR TITLE
Disable new queries logging by default

### DIFF
--- a/pg_mon.c
+++ b/pg_mon.c
@@ -52,7 +52,7 @@ PG_MODULE_MAGIC;
 /* GUC variables */
 static bool CONFIG_PLAN_INFO_IMMEDIATE = false;
 static bool CONFIG_PLAN_INFO_DISABLE = false;
-static bool CONFIG_LOG_NEW_QUERY = true;
+static bool CONFIG_LOG_NEW_QUERY = false;
 static int MON_HT_SIZE = 5000;
 
 #define MON_COLS  20


### PR DESCRIPTION
Default value for `pg_mon.log_new_query` is `false` now