### PR TITLE
Compatibility with PG16 beta1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,10 @@ jobs:
     - name: Set up packages
       run: |
         set -e
-        sudo sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg-testing main $PG\" > /etc/apt/sources.list.d/pgdg.list"
+        sudo apt-get update
+        sudo apt-get install curl ca-certificates gnupg
+        sudo sh -c "echo \"deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main $PG\" > /etc/apt/sources.list.d/pgdg.list"
+        sudo sh -c "curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg"
         sudo apt-get update
         sudo apt-get install -yq --no-install-suggests --no-install-recommends curl postgresql-common lcov libevent-dev pv brotli libbrotli1 libbrotli-dev
         # forbid creation of a main cluster when package is installed

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       PG: ${{ matrix.postgres-version }}
     strategy:
@@ -20,6 +20,7 @@ jobs:
         - '13'
         - '14'
         - '15'
+        - '16'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PG: ${{ matrix.postgres-version }}
     strategy:

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -934,12 +934,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->seq_scans[n] != 0; n++)
+                        datums[idx++] = ObjectIdGetDatum(entry->seq_scans[n]);
 #if PG_VERSION_NUM >= 160000
-                            datums[idx++] = ObjectIdGetDatum(entry->seq_scans[n]);
                     arry = construct_array_builtin(datums, idx, OIDOID);
 #else
-                            datums[idx++] = ObjectIdGetDatum(&entry->seq_scans[n]);
-                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), true, 'i');
 #endif
                     values[i++] = PointerGetDatum(arry);
                 }
@@ -951,12 +950,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->index_scans[n] != 0; n++)
+                        datums[idx++] = ObjectIdGetDatum(entry->index_scans[n]);
 #if PG_VERSION_NUM >= 160000
-                            datums[idx++] = ObjectIdGetDatum(entry->index_scans[n]);
                     arry = construct_array_builtin(datums, idx, OIDOID);
 #else
-                            datums[idx++] = ObjectIdGetDatum(&entry->index_scans[n]);
-                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), true, 'i');
 #endif
                     values[i++] = PointerGetDatum(arry);
                 }
@@ -968,12 +966,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->bitmap_scans[n] != 0; n++)
+                        datums[idx++] = ObjectIdGetDatum(entry->bitmap_scans[n]);
 #if PG_VERSION_NUM >= 160000
-                            datums[idx++] = ObjectIdGetDatum(entry->bitmap_scans[n]);
                     arry = construct_array_builtin(datums, idx, OIDOID);
 #else
-                            datums[idx++] = ObjectIdGetDatum(&entry->bitmap_scans[n]);
-                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+                    arry = construct_array(datums, idx, OIDOID, sizeof(Oid), true, 'i');
 #endif
                     values[i++] = PointerGetDatum(arry);
                 }

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -936,10 +936,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     for (n = 0; n < MAX_TABLES && entry->seq_scans[n] != 0; n++)
 #if PG_VERSION_NUM >= 160000
                             datums[idx++] = ObjectIdGetDatum(entry->seq_scans[n]);
+                    arry = construct_array_builtin(datums, idx, OIDOID);
 #else
                             datums[idx++] = ObjectIdGetDatum(&entry->seq_scans[n]);
-#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+#endif
                     values[i++] = PointerGetDatum(arry);
                 }
                 if (!entry->ModifyTable && entry->index_scans[0] == 0)
@@ -952,10 +953,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     for (n = 0; n < MAX_TABLES && entry->index_scans[n] != 0; n++)
 #if PG_VERSION_NUM >= 160000
                             datums[idx++] = ObjectIdGetDatum(entry->index_scans[n]);
+                    arry = construct_array_builtin(datums, idx, OIDOID);
 #else
                             datums[idx++] = ObjectIdGetDatum(&entry->index_scans[n]);
-#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+#endif
                     values[i++] = PointerGetDatum(arry);
                 }
                 if (!entry->ModifyTable && entry->bitmap_scans[0] == 0)
@@ -968,10 +970,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     for (n = 0; n < MAX_TABLES && entry->bitmap_scans[n] != 0; n++)
 #if PG_VERSION_NUM >= 160000
                             datums[idx++] = ObjectIdGetDatum(entry->bitmap_scans[n]);
+                    arry = construct_array_builtin(datums, idx, OIDOID);
 #else
                             datums[idx++] = ObjectIdGetDatum(&entry->bitmap_scans[n]);
-#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
+#endif
                     values[i++] = PointerGetDatum(arry);
                 }
                 values[i++] = NameGetDatum(&entry->other_scan);
@@ -991,14 +994,22 @@ pg_mon(PG_FUNCTION_ARGS)
                 {
                     numdatums[idx++] = Int64GetDatum(entry->query_time_buckets[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(numdatums, idx, INT4OID);
+#else
                 arry = construct_array(numdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
 
                 for (n = 0, idx = 0; n <= last_fill_bucket; n++)
                 {
                      numdatums[idx++] = Int64GetDatum(entry->query_time_freq[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(numdatums, idx, INT4OID);
+#else
                 arry = construct_array(numdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
                 numdatums = NULL;
                 arry = NULL;
@@ -1017,14 +1028,22 @@ pg_mon(PG_FUNCTION_ARGS)
                 {
                     rownumdatums[idx++] = Int64GetDatum(entry->actual_row_buckets[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(rownumdatums, idx, INT4OID);
+#else
                 arry = construct_array(rownumdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
 
                 for (n = 0, idx = 0; n <= last_fill_bucket; n++)
                 {
                     rownumdatums[idx++] = Int64GetDatum(entry->actual_row_freq[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(rownumdatums, idx, INT4OID);
+#else
                 arry = construct_array(rownumdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
                 last_fill_bucket = 0;
 
@@ -1040,14 +1059,22 @@ pg_mon(PG_FUNCTION_ARGS)
                 {
                     rownumdatums[idx++] = Int64GetDatum(entry->est_row_buckets[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(rownumdatums, idx, INT4OID);
+#else
                 arry = construct_array(rownumdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
 
                 for (n = 0, idx = 0; n <= last_fill_bucket; n++)
                 {
                     rownumdatums[idx++] = Int64GetDatum(entry->est_row_freq[n]);
                 }
+#if PG_VERSION_NUM >= 160000
+                arry = construct_array_builtin(rownumdatums, idx, INT4OID);
+#else
                 arry = construct_array(rownumdatums, idx, INT4OID, sizeof(int), true, 'i');
+#endif
                 values[i++] = PointerGetDatum(arry);
 
                 tuplestore_putvalues(tupstore, tupdesc, values, nulls);

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -934,7 +934,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->seq_scans[n] != 0; n++)
+#if PG_VERSION_NUM >= 160000
+                            datums[idx++] = ObjectIdGetDatum(entry->seq_scans[n]);
+#else
                             datums[idx++] = ObjectIdGetDatum(&entry->seq_scans[n]);
+#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
                     values[i++] = PointerGetDatum(arry);
                 }
@@ -946,7 +950,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->index_scans[n] != 0; n++)
+#if PG_VERSION_NUM >= 160000
+                            datums[idx++] = ObjectIdGetDatum(entry->index_scans[n]);
+#else
                             datums[idx++] = ObjectIdGetDatum(&entry->index_scans[n]);
+#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
                     values[i++] = PointerGetDatum(arry);
                 }
@@ -958,7 +966,11 @@ pg_mon(PG_FUNCTION_ARGS)
                     ArrayType  *arry;
                     int n = 0, idx = 0;
                     for (n = 0; n < MAX_TABLES && entry->bitmap_scans[n] != 0; n++)
+#if PG_VERSION_NUM >= 160000
+                            datums[idx++] = ObjectIdGetDatum(entry->bitmap_scans[n]);
+#else
                             datums[idx++] = ObjectIdGetDatum(&entry->bitmap_scans[n]);
+#endif
                     arry = construct_array(datums, idx, OIDOID, sizeof(Oid), false, 'i');
                     values[i++] = PointerGetDatum(arry);
                 }


### PR DESCRIPTION
PG16 beta1 compatibility code:
- ObjectIdGetDatum changed the interface (\+ fix the usage for pre-16)
- Add pg16 test to the workflow
- use `construct_array_builtin` instead of `construct_array`

update tests workflow
- import repo key
- change pgdg repo from testing to the main one
- run tests on ubuntu-lates