### PR TITLE
Require pg_stat_statements extension in shared_preload_libraries

### DIFF
--- a/pg_mon.c
+++ b/pg_mon.c
@@ -286,8 +286,17 @@ shmem_shutdown(int code, Datum arg)
 void
 _PG_init(void)
 {
+        const char *shared_preload_libraries_config;
+
         if (!process_shared_preload_libraries_in_progress)
 		    return;
+
+        shared_preload_libraries_config = GetConfigOption("shared_preload_libraries", true, false);
+        if (strstr(shared_preload_libraries_config, "pg_stat_statements") == NULL)
+        {
+            ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+                    errmsg("Failed to load pg_mon module: pg_stat_statements must be loaded via shared_preload_libraries")));
+        }
 
         DefineCustomIntVariable("pg_mon.max_statements",
                                 "Sets the maximum number of statements tracked by pg_mon.",

--- a/test.sh
+++ b/test.sh
@@ -18,6 +18,8 @@ readonly pwfile=$(tempfile)
 echo -n $PGPASSWORD > $pwfile
 initdb --pwfile=$pwfile --auth=md5
 
+echo "Starting without pg_stat_statements loaded" && pg_ctl start -w -o "--shared_preload_libraries=pg_mon --unix_socket_directories=$PGHOST" && exit 1
+
 trap cleanup QUIT TERM EXIT
 
 pg_ctl start -w -o "--shared_preload_libraries=pg_mon,pg_stat_statements --unix_socket_directories=$PGHOST"


### PR DESCRIPTION
pg_mon anyway doesn't make sense without pgss loaded