### PR TITLE
Handle 'nesting_level' in PU_hook

### DIFF
--- a/expected/pg_mon.out
+++ b/expected/pg_mon.out
@@ -364,6 +364,61 @@ select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_coun
              0 |          10 |           |             |                      0 | {1}               | {1}
 (1 row)
 
+-- Check that nothing under top-level utility statement is registered (avoid "out of shared memory" error for the inner queries)
+-- NB: the implementation with the static temp_entry var is still erroneous: the moment we start tracking "nesting_level" queries, it hits us again.
+select pg_stat_statements_reset();
+ pg_stat_statements_reset 
+--------------------------
+ 
+(1 row)
+
+create or replace function test_top_level_utility()
+RETURNS void
+language sql
+AS $$
+   select 1 from t;
+$$ ;
+select pg_mon_reset();
+ pg_mon_reset 
+--------------
+ 
+(1 row)
+
+do $proc$
+    declare
+        i integer;
+        poCounter integer := 0;
+    begin
+        while poCounter < 1400
+            loop
+                for i in select t.i from t
+                loop
+                    perform i;
+                end loop;
+            commit;
+            poCounter := poCounter + 1;
+        end loop;
+end $proc$;
+begin;
+declare test_top_level_utility cursor for select test_top_level_utility();
+fetch from test_top_level_utility;
+ test_top_level_utility 
+------------------------
+ 
+(1 row)
+
+fetch all from test_top_level_utility;
+ test_top_level_utility 
+------------------------
+(0 rows)
+
+end;
+select query from pg_stat_statements right join pg_mon using (queryid);
+         query         
+-----------------------
+ select pg_mon_reset()
+(1 row)
+
 --Cleanup
 drop table t;
 drop table t2;

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -542,14 +542,30 @@ _PU_HOOK
                 break;
         }
     }
-    if (prev_ProcessUtility)
+    nesting_level++;
+    PG_TRY();
     {
-        _prev_hook;
+        if (prev_ProcessUtility)
+            _prev_hook;
+        else
+            _standard_ProcessUtility;
+#if PG_VERSION_NUM < 130000
+        nesting_level--;
+#endif
     }
-    else
+#if PG_VERSION_NUM < 130000
+    PG_CATCH();
+	{
+		nesting_level--;
+		PG_RE_THROW();
+	}
+#else
+    PG_FINALLY();
     {
-        _standard_ProcessUtility;
+        nesting_level--;
     }
+#endif
+    PG_END_TRY();
 }
 
 static void

--- a/test.sh
+++ b/test.sh
@@ -20,6 +20,6 @@ initdb --pwfile=$pwfile --auth=md5
 
 trap cleanup QUIT TERM EXIT
 
-pg_ctl start -w -o "--shared_preload_libraries=pg_mon,pg_stat_statements --unix_socket_directories=$PGHOST"
+pg_ctl start -w -o "--shared_preload_libraries=pg_mon,pg_stat_statements --unix_socket_directories=$PGHOST --pg_mon.max_statements=100"
 
 make USE_PGXS=1 installcheck || diff -u expected/pg_mon.out results/pg_mon.out


### PR DESCRIPTION
This was anyway an oversight, as we seem to only track top-level queries here, while there are quite a lot of executor commands wrapped by an utility one.
Originally, however, this commit addresses the problem of the current multi-level query handling implementation based on a temporary "static variable" storage. It almost always works, except when an executor query is wrapped by a cursor's lifetime given cursor command actually has queryId assigned (loops inside plpg block). So far, I can only think of a loop inside a plpg - simple declare cursor doesn't have queryId defined. In this case static variable keeps storing the inner command's queryid, which is stored in the htab entry's payload inside the ExecutorEnd hook, while the entry's key used for lookup is the proper one, so we don't find an entry for the outer query each time and store it with the inner's query queryid as a key.