### PR TITLE
Compatibility with pg17 beta3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
         - '14'
         - '15'
         - '16'
+        - '17'
 
     steps:
     - uses: actions/checkout@v2

--- a/expected/pg_mon.out
+++ b/expected/pg_mon.out
@@ -26,10 +26,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t;
@@ -63,10 +63,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t where i < 5;
@@ -133,10 +133,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 set enable_indexscan = 'off';
@@ -155,10 +155,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 set enable_indexscan = 'on';
@@ -176,10 +176,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 set enable_indexscan = 'off';
@@ -199,10 +199,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
@@ -233,10 +233,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
@@ -267,10 +267,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
@@ -302,10 +302,10 @@ select pg_mon_reset();
  
 (1 row)
 
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select * from t, t2 where t.i = t2.i;
@@ -331,10 +331,10 @@ select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_coun
 
 -- Cover the path for skipping plan time information
 set pg_mon.plan_info_disable = 'true';
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 select pg_mon_reset();
@@ -366,10 +366,10 @@ select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_coun
 
 -- Check that nothing under top-level utility statement is registered (avoid "out of shared memory" error for the inner queries)
 -- NB: the implementation with the static temp_entry var is still erroneous: the moment we start tracking "nesting_level" queries, it hits us again.
-select pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+select pg_stat_statements_reset() is not NULL as t;
+ t 
+---
+ t
 (1 row)
 
 create or replace function test_top_level_utility()

--- a/pg_mon.c
+++ b/pg_mon.c
@@ -1104,9 +1104,6 @@ pg_mon(PG_FUNCTION_ARGS)
 
         LWLockRelease(mon_lock);
 
-        /* clean up and return the tuplestore */
-        tuplestore_donestoring(tupstore);
-
         rsinfo->returnMode = SFRM_Materialize;
         rsinfo->setResult = tupstore;
         rsinfo->setDesc = tupdesc;

--- a/sql/pg_mon.sql
+++ b/sql/pg_mon.sql
@@ -19,7 +19,7 @@ set pg_mon.log_new_query = false;
 
 -- Seq scan query output
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t;
 select expected_rows, actual_rows, seq_scans, hist_time_ubounds, hist_time_freq from pg_mon where seq_scans IS NOT NULL;
 
@@ -29,7 +29,7 @@ set random_page_cost = 0;
 
 --Index scan output
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t where i < 5;
 select expected_rows, actual_rows, seq_scans, index_scans, hist_time_ubounds, hist_time_freq from pg_mon where index_scans IS NOT NULL;
 
@@ -48,7 +48,7 @@ set enable_bitmapscan = 'on';
 update t set i = 11 where i = 1;
 select seq_scans,  index_scans, update_query from pg_mon where update_query = true;
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 
 set enable_indexscan = 'off';
 set enable_bitmapscan = 'off';
@@ -57,13 +57,13 @@ select seq_scans, index_scans, update_query from pg_mon where update_query = tru
 
 --Scan information for delete statements
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 set enable_indexscan = 'on';
 set enable_bitmapscan = 'on';
 delete from t where i < 5;
 select seq_scans, index_scans, update_query from pg_mon where update_query = true;
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 
 set enable_indexscan = 'off';
 set enable_bitmapscan = 'off';
@@ -73,39 +73,39 @@ insert into t values (generate_series(1,10), repeat('bsdshkjd3h', 10));
 
 --Join output
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t, t2 where t.i = t2.i;
 select expected_rows, actual_rows, seq_scans, index_scans, hash_join_count, hist_time_ubounds, hist_time_freq from pg_mon where hash_join_count > 0;
 
 set enable_hashjoin = 'off';
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t, t2 where t.i = t2.i;
 select expected_rows, actual_rows, seq_scans, index_scans, merge_join_count, hist_time_ubounds, hist_time_freq from pg_mon where merge_join_count > 0;
 
 set enable_mergejoin = 'off';
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t, t2 where t.i = t2.i;
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where nested_loop_join_count > 0;
 
 -- Get plan information right after planning phase
 set pg_mon.plan_info_immediate = 'true';
 select pg_mon_reset();
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select * from t, t2 where t.i = t2.i;
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where nested_loop_join_count > 0;
 
 -- Cover the path for skipping plan time information
 set pg_mon.plan_info_disable = 'true';
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 select pg_mon_reset();
 select * from t, t2 where t.i = t2.i;
 select expected_rows, actual_rows, seq_scans, index_scans, nested_loop_join_count, hist_time_ubounds, hist_time_freq from pg_mon where expected_rows = 0 and actual_rows = 10;
 
 -- Check that nothing under top-level utility statement is registered (avoid "out of shared memory" error for the inner queries)
 -- NB: the implementation with the static temp_entry var is still erroneous: the moment we start tracking "nesting_level" queries, it hits us again.
-select pg_stat_statements_reset();
+select pg_stat_statements_reset() is not NULL as t;
 
 create or replace function test_top_level_utility()
 RETURNS void


### PR DESCRIPTION
- Remove tuplestore_donestoring() 
   It is not needed since 7.4 (https://github.com/postgres/postgres/commit/d61a361d1aef1231db61162d99b635b89c73169d and https://github.com/postgres/postgres/commit/75680c3d805e2323cd437ac567f0677fdfc7b680)
- Test against pg17 (https://github.com/postgres/postgres/commit/6ab1dbd26bbf307055d805feaaca16dc3e750d36)

